### PR TITLE
corrected cli.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -66,6 +66,7 @@ next.then(function() {
     fs.writeFileSync(args.output, respString);
 });
 
+var resp;
 
 // Register an application
 // This creates a key pair and handle to be associated with the application
@@ -73,7 +74,8 @@ function Register(dataIn) {
     console.log("Registering key");
 
     return token.HandleRegisterRequest(dataIn)
-    .then(function(resp) {
+    .then(function(_resp) {
+	resp = _resp;
         console.log("Registration complete. App: " + dataIn.appId + "Key Handle is: " + resp.keyHandle)
     }, function(error) {
         console.log("Registration error: " + error);
@@ -87,7 +89,8 @@ function Sign(dataIn) {
     console.log("Signing");
 
     return token.HandleSignRequest(dataIn)
-    .then(function(resp) {
+    .then(function(_resp) {
+	resp = _resp;
         console.log("Signature complete. App: " + dataIn.appId + " Key Handle is: " + resp.keyHandle)
     }, function(error) {
         console.log("Signature error:" + error);


### PR DESCRIPTION
Hi, 

I had an issue with the cli: 
```
Loading context from: vu2f
Registering key
Registration complete. App: https://localhost/app-id.jsonKey Handle is: a7a6a5bde10f6e313f0030fd9bb2e2b0
(node:21377) UnhandledPromiseRejectionWarning: ReferenceError: resp is not defined
    at /usr/lib/node_modules/virtual-u2f/cli.js:65:37
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
    at Function.Module.runMain (module.js:695:11)
    at startup (bootstrap_node.js:188:16)
    at bootstrap_node.js:609:3
(node:21377) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:21377) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
I'm using node v8.11.1, under Fedora. 


I corrected it very quickly, I'm pretty sure there is better solution. The main idea was to warn you, but apparently you disabled issues. 